### PR TITLE
Had to change the dependency name to get a full .jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
               <artifactSet>
                 <includes>
                   <include>com.beust:jcommander</include>
-                  <include>org.apache.commons:commons-io</include>
+                  <include>commons-io:commons-io</include>
                 </includes>
               </artifactSet>              
               <transformers>
@@ -48,7 +48,7 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.2</version>
     </dependency>


### PR DESCRIPTION
... the library name has changed

I was seeing the following after running "mvn clean package"

[WARNING] While downloading org.apache.commons:commons-io:1.3.2
  This artifact has been relocated to commons-io:commons-io:1.3.2.
  https://issues.sonatype.org/browse/MVNCENTRAL-244
